### PR TITLE
Fixing name of npm package in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jquery-plugin",
+  "name": "django-superformset",
   "version": "0.0.0-ignored",
   "engines": {
     "node": ">= 0.8.0"


### PR DESCRIPTION
When `npm install`, this plugin is installed to `node_modules/jquery-plugin`, which is not intuitive and may collide with other plugins.